### PR TITLE
`panel info_json` command, returns info in JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ picoleaf effect select <name>  # Activate the named effect
 picoleaf effect custom [<panel> <red> <green> <blue> <transition time>] ...
 
 # Panel properties
-picoleaf panel info     # Print all panel information
-picoleaf panel model    # Print Nanoleaf model
-picoleaf panel name     # Print Nanoleaf name
-picoleaf panel version  # Print Nanoleaf and rhythm module versions
+picoleaf panel info      # Print all panel information
+picoleaf panel info_json # Print all panel information in json format
+picoleaf panel model     # Print Nanoleaf model
+picoleaf panel name      # Print Nanoleaf name
+picoleaf panel version   # Print Nanoleaf and rhythm module versions
 ```

--- a/client.go
+++ b/client.go
@@ -162,15 +162,15 @@ type PanelInfo struct {
 }
 
 // GetPanelInfo returns the Nanoleaf panel info.
-func (c Client) GetPanelInfo() (*PanelInfo, error) {
+func (c Client) GetPanelInfo() (*PanelInfo, string, error) {
 	body, err := c.Get("")
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	var panelInfo PanelInfo
 	err = json.Unmarshal([]byte(body), &panelInfo)
-	return &panelInfo, err
+	return &panelInfo, string(body), err
 }
 
 // ListEffects returns an array of effect names.

--- a/main.go
+++ b/main.go
@@ -231,6 +231,7 @@ func doEffectCommand(client Client, args []string) {
 func doPanelCommand(client Client, args []string) {
 	usage := func() {
 		fmt.Println("usage: picoleaf panel info")
+		fmt.Println("       picoleaf panel info_json")
 		fmt.Println("       picoleaf panel model")
 		fmt.Println("       picoleaf panel name")
 		fmt.Println("       picoleaf panel version")
@@ -241,7 +242,7 @@ func doPanelCommand(client Client, args []string) {
 		usage()
 	}
 
-	panelInfo, err := client.GetPanelInfo()
+	panelInfo, body, err := client.GetPanelInfo()
 	if err != nil {
 		fmt.Println("error: failed to get Nanoleaf state:", err)
 		os.Exit(1)
@@ -298,6 +299,8 @@ func doPanelCommand(client Client, args []string) {
 		fmt.Println("    Hardware:", panelInfo.Rhythm.HardwareVersion)
 		fmt.Println("    Firmware:", panelInfo.Rhythm.FirmwareVersion)
 		fmt.Println()
+	case "info_json":
+		fmt.Println(body)
 	case "layout":
 		fmt.Printf("Orientation: %d° [%d°-%d°]\n", panelInfo.PanelLayout.GlobalOrientation.Value, panelInfo.PanelLayout.GlobalOrientation.Min, panelInfo.PanelLayout.GlobalOrientation.Max)
 		fmt.Println("Panels:     ", panelInfo.PanelLayout.Layout.NumPanels)


### PR DESCRIPTION
New command that returns the info in raw JSON formatting. 
Useful if using in a script. 